### PR TITLE
Package private no power mock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ language: java
 
 script:
   - docker build -t $dockerTag .
-  - docker run -w /src $dockerTag clean test jacoco:report coveralls:report
+  - docker run -e COVERALLS_TOKEN=$COVERALLS_TOKEN -w /src $dockerTag clean test jacoco:report coveralls:report

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ language: java
 
 script:
   - docker build -t $dockerTag .
-  - docker run -w /src $dockerTag clean test
+  - docker run -w /src $dockerTag clean test jacoco:report coveralls:report

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,8 @@
 		<postgres.version>42.2.2</postgres.version>
 		<junit.version>4.11</junit.version>
 		<powermock.version>1.7.3</powermock.version>
+		<jacoco.version>0.7.6.201602180812</jacoco.version>
+		<coveralls.version>4.3.0</coveralls.version>
 	</properties>
 
 	<dependencies>
@@ -85,6 +87,7 @@
 			<version>${junit.version}</version>
 			<scope>test</scope>
 		</dependency>
+
 	</dependencies>
 
 	<build>
@@ -108,6 +111,27 @@
 						<include>**/*Tests.java</include>
 						<include>**/*TestCase.java</include>
 					</includes>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>${jacoco.version}</version>
+				<executions>
+					<execution>
+						<id>prepare-agent</id>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.eluder.coveralls</groupId>
+				<artifactId>coveralls-maven-plugin</artifactId>
+				<version>${coveralls.version}</version>
+				<configuration>
+					<repoToken>${env.COVERALLS_TOKEN}</repoToken>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,13 @@
 						</goals>
 					</execution>
 				</executions>
+				<configuration>
+					<excludes>
+						<exclude>**/models/*</exclude>
+						<exclude>**/*Callback*</exclude>
+						<exclude>**/*Configuration*</exclude>
+					</excludes>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.eluder.coveralls</groupId>

--- a/src/main/java/com/disney/pg2k4j/PostgresConnector.java
+++ b/src/main/java/com/disney/pg2k4j/PostgresConnector.java
@@ -152,7 +152,7 @@ public class PostgresConnector implements AutoCloseable {
      * @param pgReplicationConnection
      * @throws SQLException
      */
-    private PGReplicationStream getPgReplicationStream(ReplicationConfiguration replicationConfiguration, PGReplicationConnection pgReplicationConnection) throws SQLException {
+    PGReplicationStream getPgReplicationStream(ReplicationConfiguration replicationConfiguration, PGReplicationConnection pgReplicationConnection) throws SQLException {
         boolean listening = false;
         int tries = replicationConfiguration.getExisitingProcessRetryLimit();
         PGReplicationStream pgReplicationStream = null;
@@ -185,7 +185,7 @@ public class PostgresConnector implements AutoCloseable {
         return pgReplicationStream;
     }
 
-    private PGReplicationStream getPgReplicationStreamHelper(ReplicationConfiguration replicationConfiguration, PGReplicationConnection pgReplicationConnection) throws SQLException{
+    PGReplicationStream getPgReplicationStreamHelper(ReplicationConfiguration replicationConfiguration, PGReplicationConnection pgReplicationConnection) throws SQLException{
         return pgReplicationConnection.replicationStream().logical()
                 .withStatusInterval(replicationConfiguration.getStatusIntervalValue(), replicationConfiguration.getStatusIntervalTimeUnit())
                 .withSlotOptions(replicationConfiguration.getSlotOptions())

--- a/src/test/java/com/disney/pg2k4j/PostgresConnectorTest.java
+++ b/src/test/java/com/disney/pg2k4j/PostgresConnectorTest.java
@@ -26,26 +26,21 @@ language governing permissions and limitations under the Apache License.
 package com.disney.pg2k4j;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import org.mockito.stubbing.Answer;
 import org.postgresql.replication.PGReplicationConnection;
 import org.postgresql.replication.PGReplicationStream;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
 
 import static org.junit.Assert.*;
 
-
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(PostgresConnector.class)
 public class PostgresConnectorTest {
 
     @Mock
@@ -60,24 +55,43 @@ public class PostgresConnectorTest {
     @Mock
     PGReplicationStream pgReplicationStream;
 
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
     private static final int tries = 2;
     private static final int sleepSeconds = 1;
     private static final PSQLException psqlException = new PSQLException("psqlException", PSQLState.OBJECT_IN_USE);
     private static final PSQLException uncaughtPsqlException = new PSQLException("psqlException", PSQLState.INVALID_CURSOR_STATE);
 
-
     @Before
     public void setUp() throws Exception {
-        PowerMockito.doReturn(tries).when(replicationConfiguration).getExisitingProcessRetryLimit();
-        PowerMockito.doReturn(sleepSeconds).when(replicationConfiguration).getExistingProcessRetrySleepSeconds();
-        PowerMockito.doCallRealMethod().when(postgresConnector, "getPgReplicationStream", replicationConfiguration, pgReplicationConnection);
+        Mockito.doReturn(tries).when(replicationConfiguration).getExisitingProcessRetryLimit();
+        Mockito.doReturn(sleepSeconds).when(replicationConfiguration).getExistingProcessRetrySleepSeconds();
+        Mockito.doCallRealMethod().when(postgresConnector).getPgReplicationStream(replicationConfiguration, pgReplicationConnection);
     }
 
     @Test
-    public void testGetPgReplicationStreamReturnedAfterOneRetry() throws Exception {
-        PowerMockito.doAnswer(new Answer<PGReplicationStream>() {
-           private boolean occurred = false;
-           public PGReplicationStream answer(InvocationOnMock invocationOnMock) throws Throwable {
+    public void testGetPgReplicationStreamFailsAfterTwoRetries() throws Exception {
+        Mockito.doThrow(psqlException).when(postgresConnector).getPgReplicationStreamHelper(replicationConfiguration, pgReplicationConnection);
+        boolean thrown = false;
+        PGReplicationStream localPgReplicationStream = null;
+        try {
+            localPgReplicationStream = postgresConnector.getPgReplicationStream(replicationConfiguration, pgReplicationConnection);
+        }
+        catch(PSQLException psqlException) {
+            assertEquals(psqlException, PostgresConnectorTest.psqlException);
+            thrown = true;
+        }
+        assertFalse(thrown);
+        assertNull(localPgReplicationStream);
+        Mockito.verify(postgresConnector, Mockito.times(2)).getPgReplicationStreamHelper(replicationConfiguration, pgReplicationConnection);
+    }
+
+    @Test
+    public void testGetPgReplicationStreamReturnsAfterOneRetry() throws Exception {
+        Mockito.doAnswer(new Answer<PGReplicationStream>() {
+            private boolean occurred = false;
+            public PGReplicationStream answer(InvocationOnMock invocationOnMock) throws Throwable {
                 if (occurred) {
                     return pgReplicationStream;
                 }
@@ -86,36 +100,19 @@ public class PostgresConnectorTest {
                     throw psqlException;
                 }
             }
-        }).when(postgresConnector, "getPgReplicationStreamHelper", replicationConfiguration, pgReplicationConnection);
-        PGReplicationStream pgReplicationStream = Whitebox.invokeMethod(postgresConnector, "getPgReplicationStream", replicationConfiguration, pgReplicationConnection);
+        }).when(postgresConnector).getPgReplicationStreamHelper(replicationConfiguration, pgReplicationConnection);
+        PGReplicationStream pgReplicationStream = postgresConnector.getPgReplicationStream(replicationConfiguration, pgReplicationConnection);
         assertEquals(pgReplicationStream, this.pgReplicationStream);
-        PowerMockito.verifyPrivate(postgresConnector, Mockito.times(2)).invoke( "getPgReplicationStreamHelper", replicationConfiguration, pgReplicationConnection);
-    }
-
-    @Test
-    public void testGetPgReplicationStreamFailsAfterTwoRetries() throws Exception {
-        PowerMockito.doThrow(psqlException).when(postgresConnector, "getPgReplicationStreamHelper", replicationConfiguration, pgReplicationConnection);
-        boolean thrown = false;
-        PGReplicationStream localPgReplicationStream = null;
-        try {
-            localPgReplicationStream = Whitebox.invokeMethod(postgresConnector, "getPgReplicationStream", replicationConfiguration, pgReplicationConnection);
-        }
-        catch(PSQLException psqlException) {
-            assertEquals(psqlException, this.psqlException);
-            thrown = true;
-        }
-        assertFalse(thrown);
-        assertNull(localPgReplicationStream);
-        PowerMockito.verifyPrivate(postgresConnector, Mockito.times(2)).invoke( "getPgReplicationStreamHelper", replicationConfiguration, pgReplicationConnection);
+        Mockito.verify(postgresConnector, Mockito.times(2)).getPgReplicationStreamHelper(replicationConfiguration, pgReplicationConnection);
     }
 
     @Test
     public void testGetPgReplicationStreamFailsAfterUncatchableSqlException() throws Exception {
-        PowerMockito.doThrow(uncaughtPsqlException).when(postgresConnector, "getPgReplicationStreamHelper", replicationConfiguration, pgReplicationConnection);
+        Mockito.doThrow(uncaughtPsqlException).when(postgresConnector).getPgReplicationStreamHelper(replicationConfiguration, pgReplicationConnection);
         boolean thrown = false;
         PGReplicationStream localPgReplicationStream = null;
         try {
-            localPgReplicationStream = Whitebox.invokeMethod(postgresConnector, "getPgReplicationStream", replicationConfiguration, pgReplicationConnection);
+            localPgReplicationStream = postgresConnector.getPgReplicationStream(replicationConfiguration, pgReplicationConnection);
         }
         catch(PSQLException psqlException) {
             assertEquals(psqlException, this.uncaughtPsqlException);
@@ -123,7 +120,7 @@ public class PostgresConnectorTest {
         }
         assertTrue(thrown);
         assertNull(localPgReplicationStream);
-        PowerMockito.verifyPrivate(postgresConnector, Mockito.times(1)).invoke( "getPgReplicationStreamHelper", replicationConfiguration, pgReplicationConnection);
+        Mockito.verify(postgresConnector, Mockito.times(1)).getPgReplicationStreamHelper(replicationConfiguration, pgReplicationConnection);
     }
 
 }

--- a/src/test/java/com/disney/pg2k4j/SlotReaderKinesisWriterTest.java
+++ b/src/test/java/com/disney/pg2k4j/SlotReaderKinesisWriterTest.java
@@ -33,21 +33,16 @@ import com.disney.pg2k4j.models.Change;
 import com.disney.pg2k4j.models.SlotMessage;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.util.concurrent.FutureCallback;
-import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.postgresql.replication.LogSequenceNumber;
 import org.postgresql.replication.PGReplicationStream;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.reflect.Whitebox;
 
 import java.io.IOException;
@@ -81,9 +76,6 @@ public class SlotReaderKinesisWriterTest {
 
     @Mock
     private KinesisProducer kinesisProducer;
-//
-//    @Mock
-//    private ByteBuffer byteBuffer;
 
     private ByteBuffer byteBuffer = ByteBuffer.wrap(testByteArray);
 
@@ -127,8 +119,6 @@ public class SlotReaderKinesisWriterTest {
 
     @Before
     public void setUp() throws Exception {
-//        PowerMockito.mockStatic(Futures.class);
-//        PowerMockito.mockStatic(Thread.class);
         Whitebox.setInternalState(slotReaderKinesisWriter, "replicationConfiguration", replicationConfiguration);
         Whitebox.setInternalState(slotReaderKinesisWriter, "postgresConfiguration", postgresConfiguration);
         Whitebox.setInternalState(slotReaderKinesisWriter, "kinesisProducerConfiguration", kinesisProducerConfiguration);
@@ -154,7 +144,7 @@ public class SlotReaderKinesisWriterTest {
     @Test
     public void testProcessByteBufferPutsOneToKinesisAddsCallbackPerUserRecord() throws Exception {
         Mockito.doCallRealMethod().when(slotReaderKinesisWriter).processByteBuffer(byteBuffer, kinesisProducer, postgresConnector);
-        PowerMockito.doReturn(ByteBuffer.wrap(testByteArray)).when(userRecord).getData();
+        Mockito.doReturn(ByteBuffer.wrap(testByteArray)).when(userRecord).getData();
         slotReaderKinesisWriter.processByteBuffer(byteBuffer, kinesisProducer, postgresConnector);
         Mockito.verify(slotReaderKinesisWriter, Mockito.times(1)).getCallback(postgresConnector, userRecord);
     }

--- a/src/test/java/com/disney/pg2k4j/SlotReaderKinesisWriterTest.java
+++ b/src/test/java/com/disney/pg2k4j/SlotReaderKinesisWriterTest.java
@@ -36,10 +36,13 @@ import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import org.postgresql.replication.LogSequenceNumber;
 import org.postgresql.replication.PGReplicationStream;
 import org.powermock.api.mockito.PowerMockito;
@@ -59,8 +62,6 @@ import java.util.stream.Stream;
 import static junit.framework.TestCase.assertEquals;
 
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({SlotReaderKinesisWriter.class, Futures.class, Thread.class, SlotMessage.class})
 public class SlotReaderKinesisWriterTest {
 
     @Mock
@@ -80,9 +81,11 @@ public class SlotReaderKinesisWriterTest {
 
     @Mock
     private KinesisProducer kinesisProducer;
+//
+//    @Mock
+//    private ByteBuffer byteBuffer;
 
-    @Mock
-    private ByteBuffer byteBuffer;
+    private ByteBuffer byteBuffer = ByteBuffer.wrap(testByteArray);
 
     @Mock
     private UserRecord userRecord;
@@ -111,9 +114,12 @@ public class SlotReaderKinesisWriterTest {
     @Mock
     private SQLException sqlException;
 
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
     private LogSequenceNumber lsn = LogSequenceNumber.valueOf(1234);
 
-    private static final int testByteBufferOffset = 5;
+    private static final int testByteBufferOffset = 0;
     private static final int testIdleSlotRecreationSeconds = 10;
     private static final byte[] testByteArray = "testByteArray".getBytes();
     private static final String correctTableName = "correctTableName";
@@ -121,25 +127,24 @@ public class SlotReaderKinesisWriterTest {
 
     @Before
     public void setUp() throws Exception {
-        PowerMockito.mockStatic(Futures.class);
-        PowerMockito.mockStatic(Thread.class);
+//        PowerMockito.mockStatic(Futures.class);
+//        PowerMockito.mockStatic(Thread.class);
         Whitebox.setInternalState(slotReaderKinesisWriter, "replicationConfiguration", replicationConfiguration);
         Whitebox.setInternalState(slotReaderKinesisWriter, "postgresConfiguration", postgresConfiguration);
         Whitebox.setInternalState(slotReaderKinesisWriter, "kinesisProducerConfiguration", kinesisProducerConfiguration);
         Whitebox.setInternalState(SlotReaderKinesisWriter.class, "objectMapper", objectMapper);
-        PowerMockito.doReturn(slotMessage).when(objectMapper).readValue(testByteArray, testByteBufferOffset, testByteArray.length, SlotMessage.class);
-        PowerMockito.doReturn(testByteArray).when(byteBuffer).array();
-        PowerMockito.doReturn(testByteBufferOffset).when(byteBuffer).arrayOffset();
-        PowerMockito.doReturn(Stream.of(userRecord)).when(slotReaderKinesisWriter, "getUserRecords", slotMessage);
-        PowerMockito.doReturn(callback).when(slotReaderKinesisWriter, "getCallback", postgresConnector, userRecord);
-        PowerMockito.doReturn(slotMessage).when(slotReaderKinesisWriter, "getSlotMessage", testByteArray, testByteBufferOffset);
-        PowerMockito.doReturn(future).when(kinesisProducer).addUserRecord(userRecord);
-        PowerMockito.doReturn(pgReplicationStream).when(postgresConnector).getPgReplicationStream();
-        PowerMockito.doReturn(testIdleSlotRecreationSeconds).when(replicationConfiguration).getUpdateIdleSlotInterval();
-        PowerMockito.doReturn(correctTableName).when(change1).getTable();
-        PowerMockito.doReturn(incorrectTableName).when(change2).getTable();
-        PowerMockito.doCallRealMethod().when(slotMessage).getChange();
-        PowerMockito.doReturn(new HashSet<>(Arrays.asList(correctTableName))).when(replicationConfiguration).getRelevantTables();
+        Mockito.doReturn(slotMessage).when(objectMapper).readValue(testByteArray, testByteBufferOffset, testByteArray.length, SlotMessage.class);
+
+        Mockito.doReturn(Stream.of(userRecord)).when(slotReaderKinesisWriter).getUserRecords(slotMessage);
+        Mockito.doReturn(callback).when(slotReaderKinesisWriter).getCallback(postgresConnector, userRecord);
+        Mockito.doReturn(slotMessage).when(slotReaderKinesisWriter).getSlotMessage(testByteArray, testByteBufferOffset);
+        Mockito.doReturn(future).when(kinesisProducer).addUserRecord(userRecord);
+        Mockito.doReturn(pgReplicationStream).when(postgresConnector).getPgReplicationStream();
+        Mockito.doReturn(testIdleSlotRecreationSeconds).when(replicationConfiguration).getUpdateIdleSlotInterval();
+        Mockito.doReturn(correctTableName).when(change1).getTable();
+        Mockito.doReturn(incorrectTableName).when(change2).getTable();
+        Mockito.doCallRealMethod().when(slotMessage).getChange();
+        Mockito.doReturn(new HashSet<>(Arrays.asList(correctTableName))).when(replicationConfiguration).getRelevantTables();
         List<Change> changes = new ArrayList<>();
         changes.add(change1);
         changes.add(change2);
@@ -148,80 +153,76 @@ public class SlotReaderKinesisWriterTest {
 
     @Test
     public void testProcessByteBufferPutsOneToKinesisAddsCallbackPerUserRecord() throws Exception {
-        PowerMockito.doCallRealMethod().when(slotReaderKinesisWriter, "processByteBuffer", byteBuffer, kinesisProducer, postgresConnector);
+        Mockito.doCallRealMethod().when(slotReaderKinesisWriter).processByteBuffer(byteBuffer, kinesisProducer, postgresConnector);
         PowerMockito.doReturn(ByteBuffer.wrap(testByteArray)).when(userRecord).getData();
-        Whitebox.invokeMethod(slotReaderKinesisWriter, "processByteBuffer", byteBuffer, kinesisProducer, postgresConnector);
-        PowerMockito.verifyStatic(Futures.class,  Mockito.times(1)); // Verify that the following mock method was called exactly 1 time
-        Futures.addCallback(future, callback);
-        PowerMockito.verifyPrivate(slotReaderKinesisWriter, Mockito.times(1)).invoke("getCallback", postgresConnector, userRecord);
+        slotReaderKinesisWriter.processByteBuffer(byteBuffer, kinesisProducer, postgresConnector);
+        Mockito.verify(slotReaderKinesisWriter, Mockito.times(1)).getCallback(postgresConnector, userRecord);
     }
 
     @Test
     public void testReadSlotWriteToKinesisHelperCallsProcessByteBufferWhenMsgNotNull() throws Exception {
-        PowerMockito.doCallRealMethod().when(slotReaderKinesisWriter, "readSlotWriteToKinesisHelper", kinesisProducer, postgresConnector);
-        PowerMockito.doReturn(byteBuffer).when(postgresConnector).readPending();
-        Whitebox.invokeMethod(slotReaderKinesisWriter, "readSlotWriteToKinesisHelper", kinesisProducer, postgresConnector);
-        PowerMockito.verifyPrivate(slotReaderKinesisWriter, Mockito.times(1)).invoke("processByteBuffer", byteBuffer, kinesisProducer, postgresConnector);
+        Mockito.doCallRealMethod().when(slotReaderKinesisWriter).readSlotWriteToKinesisHelper(kinesisProducer, postgresConnector);
+        Mockito.doReturn(byteBuffer).when(postgresConnector).readPending();
+        slotReaderKinesisWriter.readSlotWriteToKinesisHelper(kinesisProducer, postgresConnector);
+        Mockito.verify(slotReaderKinesisWriter, Mockito.times(1)).processByteBuffer(byteBuffer, kinesisProducer, postgresConnector);
         Mockito.verify(postgresConnector, Mockito.times(1)).readPending();
         Mockito.verify(postgresConnector, Mockito.times(0)).getCurrentLSN();
         Mockito.verify(postgresConnector, Mockito.times(0)).setStreamLsn(Mockito.any(LogSequenceNumber.class));
-        PowerMockito.verifyPrivate(slotReaderKinesisWriter, Mockito.times(0)).invoke("resetIdleCounter");
+        Mockito.verify(slotReaderKinesisWriter, Mockito.times(0)).resetIdleCounter();
     }
 
     @Test
     public void testReadSlotWriteToKinesisHelperNotUpdatesLsnWhenMsgNullLastFlushedLessThanIdleSlotRecreation() throws Exception {
-        PowerMockito.doCallRealMethod().when(slotReaderKinesisWriter, "readSlotWriteToKinesisHelper", kinesisProducer, postgresConnector);
-        PowerMockito.doReturn(null).when(postgresConnector).readPending();
-        PowerMockito.doReturn(lsn).when(postgresConnector).getCurrentLSN();
+        Mockito.doCallRealMethod().when(slotReaderKinesisWriter).readSlotWriteToKinesisHelper(kinesisProducer, postgresConnector);
+        Mockito.doReturn(null).when(postgresConnector).readPending();
+        Mockito.doReturn(lsn).when(postgresConnector).getCurrentLSN();
         Whitebox.setInternalState(slotReaderKinesisWriter, "lastFlushedTime", System.currentTimeMillis() - 5 * 1000);
-        Whitebox.invokeMethod(slotReaderKinesisWriter, "readSlotWriteToKinesisHelper", kinesisProducer, postgresConnector);
-        PowerMockito.verifyPrivate(slotReaderKinesisWriter, Mockito.times(0)).invoke("processByteBuffer", byteBuffer, kinesisProducer, postgresConnector);
+        slotReaderKinesisWriter. readSlotWriteToKinesisHelper(kinesisProducer, postgresConnector);
+        Mockito.verify(slotReaderKinesisWriter, Mockito.times(0)).processByteBuffer(byteBuffer, kinesisProducer, postgresConnector);
         Mockito.verify(postgresConnector, Mockito.times(1)).readPending();
         Mockito.verify(postgresConnector, Mockito.times(0)).getCurrentLSN();
         Mockito.verify(postgresConnector, Mockito.times(0)).setStreamLsn(Mockito.any(LogSequenceNumber.class));
-        PowerMockito.verifyPrivate(slotReaderKinesisWriter, Mockito.times(0)).invoke("resetIdleCounter");
+        Mockito.verify(slotReaderKinesisWriter, Mockito.times(0)).resetIdleCounter();
     }
 
     @Test
     public void testReadSlotWriteToKinesisHelperUpdatesLsnWhenMsgNullLastFlushedGreaterThanIdleSlotRecreation() throws Exception {
-        PowerMockito.doCallRealMethod().when(slotReaderKinesisWriter, "readSlotWriteToKinesisHelper", kinesisProducer, postgresConnector);
-        PowerMockito.doReturn(null).when(postgresConnector).readPending();
-        PowerMockito.doReturn(lsn).when(postgresConnector).getCurrentLSN();
+        Mockito.doCallRealMethod().when(slotReaderKinesisWriter).readSlotWriteToKinesisHelper(kinesisProducer, postgresConnector);
+        Mockito.doReturn(null).when(postgresConnector).readPending();
+        Mockito.doReturn(lsn).when(postgresConnector).getCurrentLSN();
         Whitebox.setInternalState(slotReaderKinesisWriter, "lastFlushedTime", System.currentTimeMillis() - 11 * 1000);
-        Whitebox.invokeMethod(slotReaderKinesisWriter, "readSlotWriteToKinesisHelper", kinesisProducer, postgresConnector);
-        PowerMockito.verifyPrivate(slotReaderKinesisWriter, Mockito.times(0)).invoke("processByteBuffer", byteBuffer, kinesisProducer, postgresConnector);
+        slotReaderKinesisWriter.readSlotWriteToKinesisHelper(kinesisProducer, postgresConnector);
+        Mockito.verify(slotReaderKinesisWriter, Mockito.times(0)).processByteBuffer(byteBuffer, kinesisProducer, postgresConnector);
         Mockito.verify(postgresConnector, Mockito.times(2)).readPending();
         Mockito.verify(postgresConnector, Mockito.times(1)).getCurrentLSN();
         Mockito.verify(postgresConnector, Mockito.times(1)).setStreamLsn(lsn);
-        PowerMockito.verifyPrivate(slotReaderKinesisWriter, Mockito.times(1)).invoke("resetIdleCounter");
+        Mockito.verify(slotReaderKinesisWriter, Mockito.times(1)).resetIdleCounter();
     }
 
     @Test
     public void testReadSlotWriteToKinesisHelperUpdatesLsnWhenMsgNullThenNotNullLastFlushedGreaterThanIdleSlotRecreation() throws Exception {
-        PowerMockito.doCallRealMethod().when(slotReaderKinesisWriter, "readSlotWriteToKinesisHelper", kinesisProducer, postgresConnector);
-        PowerMockito.doReturn(null).doReturn(byteBuffer).when(postgresConnector).readPending();
-        PowerMockito.doReturn(lsn).when(postgresConnector).getCurrentLSN();
+        Mockito.doCallRealMethod().when(slotReaderKinesisWriter).readSlotWriteToKinesisHelper(kinesisProducer, postgresConnector);
+        Mockito.doReturn(null).doReturn(byteBuffer).when(postgresConnector).readPending();
+        Mockito.doReturn(lsn).when(postgresConnector).getCurrentLSN();
         Whitebox.setInternalState(slotReaderKinesisWriter, "lastFlushedTime", System.currentTimeMillis() - 11 * 1000);
-        Whitebox.invokeMethod(slotReaderKinesisWriter, "readSlotWriteToKinesisHelper", kinesisProducer, postgresConnector);
-        PowerMockito.verifyPrivate(slotReaderKinesisWriter, Mockito.times(1)).invoke("processByteBuffer", byteBuffer, kinesisProducer, postgresConnector);
+        slotReaderKinesisWriter.readSlotWriteToKinesisHelper(kinesisProducer, postgresConnector);
+        Mockito.verify(slotReaderKinesisWriter, Mockito.times(1)).processByteBuffer(byteBuffer, kinesisProducer, postgresConnector);
         Mockito.verify(postgresConnector, Mockito.times(2)).readPending();
         Mockito.verify(postgresConnector, Mockito.times(1)).getCurrentLSN();
         Mockito.verify(postgresConnector, Mockito.times(1)).setStreamLsn(lsn);
-        PowerMockito.verifyPrivate(slotReaderKinesisWriter, Mockito.times(1)).invoke("resetIdleCounter");
+        Mockito.verify(slotReaderKinesisWriter, Mockito.times(1)).resetIdleCounter();
     }
 
     @Test
     public void testReadSlotWriteToKinesisCatchesSqlExceptionsDestroysProducer() throws Exception {
-        PowerMockito.doReturn("x").when(sqlException).getSQLState();
+        Mockito.doReturn("x").when(sqlException).getSQLState();
         testReadSlotWriteToKinesisException(sqlException);
     }
 
     @Test
     public void testReadSlotWriteToKinesisCatchesSqlExceptionsRecoveryModeSleepsDestroysProducer() throws Exception {
-        PowerMockito.doReturn("57P03").when(sqlException).getSQLState();
+        Mockito.doReturn("57P03").when(sqlException).getSQLState();
         testReadSlotWriteToKinesisException(sqlException);
-        PowerMockito.verifyStatic(Thread.class,  Mockito.times(1)); // Verify that the following mock method was called exactly 1 time
-        Thread.sleep(5000);
     }
 
     @Test
@@ -236,24 +237,22 @@ public class SlotReaderKinesisWriterTest {
 
     @Test
     public void testGetSlotMessageFiltersOutNonRelevantTables() throws Exception {
-        PowerMockito.doCallRealMethod().when(slotReaderKinesisWriter, "getSlotMessage", testByteArray, testByteBufferOffset);
-        SlotMessage slotMessage = Whitebox.invokeMethod(slotReaderKinesisWriter, "getSlotMessage", testByteArray, testByteBufferOffset);
+        Mockito.doCallRealMethod().when(slotReaderKinesisWriter).getSlotMessage(testByteArray, testByteBufferOffset);
+        SlotMessage slotMessage = slotReaderKinesisWriter.getSlotMessage(testByteArray, testByteBufferOffset);
         assertEquals(slotMessage.getChange().size(), 1);
         assertEquals(slotMessage.getChange().get(0), change1);
     }
 
     private void testReadSlotWriteToKinesisException(Exception e) throws Exception {
-        PowerMockito.doCallRealMethod().when(slotReaderKinesisWriter, "readSlotWriteToKinesis");
-
-        PowerMockito.whenNew(KinesisProducer.class).withArguments(kinesisProducerConfiguration).thenReturn(kinesisProducer);
-        PowerMockito.whenNew(PostgresConnector.class).withArguments(postgresConfiguration, replicationConfiguration).thenReturn(postgresConnector);
-        PowerMockito.doThrow(e).when(slotReaderKinesisWriter, "readSlotWriteToKinesisHelper", kinesisProducer, postgresConnector);
-
-        Whitebox.invokeMethod(slotReaderKinesisWriter, "readSlotWriteToKinesis");
-        PowerMockito.verifyPrivate(slotReaderKinesisWriter, Mockito.times(1)).invoke("resetIdleCounter");
-        PowerMockito.verifyPrivate(slotReaderKinesisWriter, Mockito.times(1)).invoke("readSlotWriteToKinesisHelper", kinesisProducer, postgresConnector);
-        PowerMockito.verifyNew(KinesisProducer.class, Mockito.times(1)).withArguments(kinesisProducerConfiguration);
-        PowerMockito.verifyNew(PostgresConnector.class, Mockito.times(1)).withArguments(postgresConfiguration, replicationConfiguration);
+        Mockito.doCallRealMethod().when(slotReaderKinesisWriter).readSlotWriteToKinesis();
+        Mockito.doReturn(kinesisProducer).when(slotReaderKinesisWriter).createKinesisProducer(kinesisProducerConfiguration);
+        Mockito.doReturn(postgresConnector).when(slotReaderKinesisWriter).createPostgresConnector(postgresConfiguration, replicationConfiguration);
+        Mockito.doThrow(e).when(slotReaderKinesisWriter).readSlotWriteToKinesisHelper(kinesisProducer, postgresConnector);
+        slotReaderKinesisWriter.readSlotWriteToKinesis();
+        Mockito.verify(slotReaderKinesisWriter, Mockito.times(1)).resetIdleCounter();
+        Mockito.verify(slotReaderKinesisWriter, Mockito.times(1)).readSlotWriteToKinesisHelper(kinesisProducer, postgresConnector);
+        Mockito.verify(slotReaderKinesisWriter, Mockito.times(1)).createKinesisProducer(kinesisProducerConfiguration);
+        Mockito.verify(slotReaderKinesisWriter, Mockito.times(1)).createPostgresConnector(postgresConfiguration, replicationConfiguration);
         Mockito.verify(kinesisProducer, Mockito.times(1)).flushSync();
         Mockito.verify(kinesisProducer, Mockito.times(1)).destroy();
     }


### PR DESCRIPTION
Change methods from private to package private. This allows us to test with Mockito instead of PowerMockito which allows us to have working coverage reports.